### PR TITLE
Fixing bug in deconfigure port workflow

### DIFF
--- a/packs/brcd_openstack/actions/workflows/deconfigure_trunk_vlan_on_interface.yaml
+++ b/packs/brcd_openstack/actions/workflows/deconfigure_trunk_vlan_on_interface.yaml
@@ -35,7 +35,7 @@ brcd_openstack.deconfigure_trunk_vlan_on_interface:
       on-success:
         - send_success_msg_to_slack
       on-error:
-        - untag_inteface_failed 
+        - untag_interface_failed 
     send_success_msg_to_slack:
       # [525, 740]
       action: chatops.post_message


### PR DESCRIPTION
Typo identified in the deconfigure_trunk_vlan_on_interface workflow while testing VM delete scenario. 
